### PR TITLE
Fix terminal_input schema consistency and improve Zod schema descriptions

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -326,7 +326,10 @@ MCP Shell Serverは、Model Context Protocol (MCP) を使用して安全かつ�
 {
   "terminal_id": "string (required) - ターミナルID",
   "input": "string (required) - 入力内容",
-  "execute": "boolean (optional, default: false) - 自動実行フラグ（Enterキーを送信）"
+  "execute": "boolean (optional, default: false) - 自動実行フラグ（Enterキーを送信）",
+  "control_codes": "boolean (optional, default: false) - 制御コードとエスケープシーケンスとして解釈",
+  "raw_bytes": "boolean (optional, default: false) - 生バイト送信（16進数文字列形式）",
+  "send_to": "string (optional) - プログラムガード対象: プロセス名、パス、\"pid:12345\"、\"sessionleader:\"、\"*\""
 }
 ```
 
@@ -335,6 +338,9 @@ MCP Shell Serverは、Model Context Protocol (MCP) を使用して安全かつ�
 {
   "success": "boolean - 成功フラグ",
   "input_sent": "string - 送信された入力",
+  "control_codes_enabled": "boolean - 制御コードモードが有効だったか",
+  "raw_bytes_mode": "boolean - 生バイトモードが有効だったか",
+  "program_guard": "object (optional) - プログラムガード結果",
   "timestamp": "string - 送信時刻"
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "mcp-shell-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-shell-server",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
         "node-pty": "^1.0.0",
         "uuid": "^10.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.5"
       },
       "devDependencies": {
         "@jest/globals": "^30.0.0",
@@ -8647,6 +8648,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@modelcontextprotocol/sdk": "^0.6.0",
     "node-pty": "^1.0.0",
     "uuid": "^10.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
     "@jest/globals": "^30.0.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   SecuritySetRestrictionsParamsSchema,
   MonitoringGetStatsParamsSchema,
 } from './types/schemas.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import { MCPShellError } from './utils/errors.js';
 
@@ -89,465 +90,95 @@ export class MCPShellServer {
         {
           name: 'shell_execute',
           description: 'Execute shell commands securely in a sandboxed environment. Can also create new interactive terminal sessions.',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              command: { type: 'string', description: 'Command to execute' },
-              execution_mode: { 
-                type: 'string', 
-                enum: ['sync', 'async', 'background'],
-                default: 'sync',
-                description: 'Execution mode'
-              },
-              working_directory: { type: 'string', description: 'Working directory' },
-              environment_variables: { 
-                type: 'object',
-                additionalProperties: { type: 'string' },
-                description: 'Environment variables'
-              },
-              input_data: { type: 'string', description: 'Standard input data' },
-              timeout_seconds: { 
-                type: 'number',
-                minimum: 1,
-                maximum: 3600,
-                default: 30,
-                description: 'Timeout in seconds'
-              },
-              max_output_size: {
-                type: 'number',
-                minimum: 1024,
-                maximum: 104857600,
-                default: 1048576,
-                description: 'Maximum output size in bytes'
-              },
-              capture_stderr: {
-                type: 'boolean',
-                default: true,
-                description: 'Capture standard error output'
-              },
-              session_id: { type: 'string', description: 'Session ID for session management' },
-              create_terminal: {
-                type: 'boolean',
-                default: false,
-                description: 'Create a new interactive terminal session instead of running command directly'
-              },
-              terminal_shell: {
-                type: 'string',
-                enum: ['bash', 'zsh', 'fish', 'sh', 'powershell'],
-                description: 'Shell type for the new terminal (only used when create_terminal is true)'
-              },
-              terminal_dimensions: {
-                type: 'object',
-                properties: {
-                  width: { type: 'number', minimum: 10, maximum: 500 },
-                  height: { type: 'number', minimum: 5, maximum: 200 }
-                },
-                description: 'Terminal dimensions (only used when create_terminal is true)'
-              }
-            },
-            required: ['command']
-          }
+          inputSchema: zodToJsonSchema(ShellExecuteParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'shell_get_execution',
           description: 'Get detailed information about a command execution',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              execution_id: { type: 'string', description: 'Execution ID' }
-            },
-            required: ['execution_id']
-          }
+          inputSchema: zodToJsonSchema(ShellGetExecutionParamsSchema, { target: 'jsonSchema7' })
         },
 
         // Process Management
         {
           name: 'process_list',
           description: 'List running or background processes',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              status_filter: {
-                type: 'string',
-                enum: ['running', 'completed', 'failed', 'all'],
-                description: 'Filter by process status'
-              },
-              command_pattern: { type: 'string', description: 'Filter by command pattern' },
-              session_id: { type: 'string', description: 'Filter by session ID' },
-              limit: {
-                type: 'number',
-                minimum: 1,
-                maximum: 500,
-                default: 50,
-                description: 'Maximum number of results'
-              },
-              offset: {
-                type: 'number',
-                minimum: 0,
-                default: 0,
-                description: 'Offset for pagination'
-              }
-            },
-            required: []
-          }
+          inputSchema: zodToJsonSchema(ProcessListParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'process_kill',
           description: 'Safely terminate a process',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              process_id: { type: 'number', description: 'Process ID' },
-              signal: {
-                type: 'string',
-                enum: ['TERM', 'KILL', 'INT', 'HUP', 'USR1', 'USR2'],
-                default: 'TERM',
-                description: 'Signal to send'
-              },
-              force: {
-                type: 'boolean',
-                default: false,
-                description: 'Force termination flag'
-              }
-            },
-            required: ['process_id']
-          }
+          inputSchema: zodToJsonSchema(ProcessKillParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'process_monitor',
           description: 'Start real-time monitoring of a process',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              process_id: { type: 'number', description: 'Process ID' },
-              monitor_interval_ms: {
-                type: 'number',
-                minimum: 100,
-                maximum: 60000,
-                default: 1000,
-                description: 'Monitoring interval in milliseconds'
-              },
-              include_metrics: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  enum: ['cpu', 'memory', 'io', 'network']
-                },
-                description: 'Metrics to monitor'
-              }
-            },
-            required: ['process_id']
-          }
+          inputSchema: zodToJsonSchema(ProcessMonitorParamsSchema, { target: 'jsonSchema7' })
         },
 
         // File Operations
         {
           name: 'file_list',
           description: 'List files and output files',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              file_type: {
-                type: 'string',
-                enum: ['output', 'log', 'temp', 'all'],
-                description: 'Filter by file type'
-              },
-              execution_id: { type: 'string', description: 'Filter by execution ID' },
-              name_pattern: { type: 'string', description: 'Filter by filename pattern' },
-              limit: {
-                type: 'number',
-                minimum: 1,
-                maximum: 1000,
-                default: 100,
-                description: 'Maximum number of results'
-              }
-            },
-            required: []
-          }
+          inputSchema: zodToJsonSchema(FileListParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'file_read',
           description: 'Read file contents',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              file_id: { type: 'string', description: 'File ID' },
-              offset: {
-                type: 'number',
-                minimum: 0,
-                default: 0,
-                description: 'Read offset'
-              },
-              size: {
-                type: 'number',
-                minimum: 1,
-                maximum: 10485760,
-                default: 8192,
-                description: 'Read size'
-              },
-              encoding: {
-                type: 'string',
-                default: 'utf-8',
-                description: 'Character encoding'
-              }
-            },
-            required: ['file_id']
-          }
+          inputSchema: zodToJsonSchema(FileReadParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'file_delete',
           description: 'Delete specified files',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              file_ids: {
-                type: 'array',
-                items: { type: 'string' },
-                minItems: 1,
-                description: 'List of file IDs to delete'
-              },
-              confirm: {
-                type: 'boolean',
-                description: 'Deletion confirmation flag'
-              }
-            },
-            required: ['file_ids', 'confirm']
-          }
+          inputSchema: zodToJsonSchema(FileDeleteParamsSchema, { target: 'jsonSchema7' })
         },
 
         // Terminal Management
         {
           name: 'terminal_create',
           description: 'Create a new interactive terminal session',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              session_name: { type: 'string', description: 'Session name' },
-              shell_type: {
-                type: 'string',
-                enum: ['bash', 'zsh', 'fish', 'cmd', 'powershell'],
-                default: 'bash',
-                description: 'Shell type'
-              },
-              dimensions: {
-                type: 'object',
-                properties: {
-                  width: {
-                    type: 'number',
-                    minimum: 1,
-                    maximum: 500,
-                    default: 120,
-                    description: 'Terminal width in characters'
-                  },
-                  height: {
-                    type: 'number',
-                    minimum: 1,
-                    maximum: 200,
-                    default: 30,
-                    description: 'Terminal height in lines'
-                  }
-                },
-                description: 'Terminal dimensions'
-              },
-              working_directory: { type: 'string', description: 'Initial working directory' },
-              environment_variables: {
-                type: 'object',
-                additionalProperties: { type: 'string' },
-                description: 'Environment variables'
-              },
-              auto_save_history: {
-                type: 'boolean',
-                default: true,
-                description: 'Auto-save command history'
-              }
-            },
-            required: []
-          }
+          inputSchema: zodToJsonSchema(TerminalCreateParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'terminal_list',
           description: 'List active terminal sessions',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              session_name_pattern: { type: 'string', description: 'Session name pattern' },
-              status_filter: {
-                type: 'string',
-                enum: ['active', 'idle', 'all'],
-                description: 'Filter by status'
-              },
-              limit: {
-                type: 'number',
-                minimum: 1,
-                maximum: 200,
-                default: 50,
-                description: 'Maximum number of results'
-              }
-            },
-            required: []
-          }
+          inputSchema: zodToJsonSchema(TerminalListParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'terminal_get',
           description: 'Get terminal detailed information',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              terminal_id: { type: 'string', description: 'Terminal ID' }
-            },
-            required: ['terminal_id']
-          }
+          inputSchema: zodToJsonSchema(TerminalGetParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'terminal_input',
           description: 'Send input to terminal',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              terminal_id: { type: 'string', description: 'Terminal ID' },
-              input: { type: 'string', description: 'Input content' },
-              execute: {
-                type: 'boolean',
-                default: false,
-                description: 'Auto-execute flag (send Enter key)'
-              }
-            },
-            required: ['terminal_id', 'input']
-          }
+          inputSchema: zodToJsonSchema(TerminalInputParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'terminal_output',
           description: 'Get terminal output',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              terminal_id: { type: 'string', description: 'Terminal ID' },
-              start_line: {
-                type: 'number',
-                minimum: 0,
-                default: 0,
-                description: 'Start line number'
-              },
-              line_count: {
-                type: 'number',
-                minimum: 1,
-                maximum: 10000,
-                default: 100,
-                description: 'Number of lines to get'
-              },
-              include_ansi: {
-                type: 'boolean',
-                default: false,
-                description: 'Include ANSI control codes'
-              }
-            },
-            required: ['terminal_id']
-          }
+          inputSchema: zodToJsonSchema(TerminalOutputParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'terminal_resize',
           description: 'Resize terminal',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              terminal_id: { type: 'string', description: 'Terminal ID' },
-              dimensions: {
-                type: 'object',
-                properties: {
-                  width: { type: 'number', minimum: 1, maximum: 500, description: 'New width' },
-                  height: { type: 'number', minimum: 1, maximum: 200, description: 'New height' }
-                },
-                required: ['width', 'height'],
-                description: 'New dimensions'
-              }
-            },
-            required: ['terminal_id', 'dimensions']
-          }
+          inputSchema: zodToJsonSchema(TerminalResizeParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'terminal_close',
           description: 'Close terminal session',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              terminal_id: { type: 'string', description: 'Terminal ID' },
-              save_history: {
-                type: 'boolean',
-                default: true,
-                description: 'Save command history'
-              }
-            },
-            required: ['terminal_id']
-          }
+          inputSchema: zodToJsonSchema(TerminalCloseParamsSchema, { target: 'jsonSchema7' })
         },
 
         // Security & Monitoring
         {
           name: 'security_set_restrictions',
           description: 'Set execution restrictions',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              allowed_commands: {
-                type: 'array',
-                items: { type: 'string' },
-                description: 'List of allowed commands'
-              },
-              blocked_commands: {
-                type: 'array',
-                items: { type: 'string' },
-                description: 'List of blocked commands'
-              },
-              allowed_directories: {
-                type: 'array',
-                items: { type: 'string' },
-                description: 'List of allowed directories'
-              },
-              max_execution_time: {
-                type: 'number',
-                minimum: 1,
-                maximum: 86400,
-                description: 'Maximum execution time in seconds'
-              },
-              max_memory_mb: {
-                type: 'number',
-                minimum: 1,
-                maximum: 32768,
-                description: 'Maximum memory usage in MB'
-              },
-              enable_network: {
-                type: 'boolean',
-                default: true,
-                description: 'Enable network access'
-              }
-            },
-            required: []
-          }
+          inputSchema: zodToJsonSchema(SecuritySetRestrictionsParamsSchema, { target: 'jsonSchema7' })
         },
         {
           name: 'monitoring_get_stats',
           description: 'Get system-wide statistics',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              include_metrics: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  enum: ['processes', 'terminals', 'files', 'system']
-                },
-                description: 'Metrics to include'
-              },
-              time_range_minutes: {
-                type: 'number',
-                minimum: 1,
-                maximum: 1440,
-                default: 60,
-                description: 'Time range in minutes'
-              }
-            },
-            required: []
-          }
+          inputSchema: zodToJsonSchema(MonitoringGetStatsParamsSchema, { target: 'jsonSchema7' })
         }
       ]
     }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,13 +36,13 @@ export const ErrorCategorySchema = z.enum([
 export type ErrorCategory = z.infer<typeof ErrorCategorySchema>;
 
 // 基本スキーマ
-export const EnvironmentVariablesSchema = z.record(z.string(), z.string());
+export const EnvironmentVariablesSchema = z.record(z.string(), z.string()).describe('Environment variables');
 export type EnvironmentVariables = z.infer<typeof EnvironmentVariablesSchema>;
 
 export const DimensionsSchema = z.object({
-  width: z.number().int().min(1).max(500),
-  height: z.number().int().min(1).max(200),
-});
+  width: z.number().int().min(1).max(500).describe('Width in characters'),
+  height: z.number().int().min(1).max(200).describe('Height in lines'),
+}).describe('Terminal dimensions');
 export type Dimensions = z.infer<typeof DimensionsSchema>;
 
 // 実行オプション

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -10,135 +10,137 @@ import {
 
 // Shell Operations
 export const ShellExecuteParamsSchema = z.object({
-  command: z.string().min(1),
-  execution_mode: ExecutionModeSchema.default('sync'),
-  working_directory: z.string().optional(),
-  environment_variables: EnvironmentVariablesSchema.optional(),
-  input_data: z.string().optional(),
-  timeout_seconds: z.number().int().min(1).max(3600).default(30),
+  command: z.string().min(1).describe('Command to execute'),
+  execution_mode: ExecutionModeSchema.default('sync').describe('Execution mode'),
+  working_directory: z.string().optional().describe('Working directory'),
+  environment_variables: EnvironmentVariablesSchema.optional().describe('Environment variables'),
+  input_data: z.string().optional().describe('Standard input data'),
+  timeout_seconds: z.number().int().min(1).max(3600).default(30).describe('Timeout in seconds'),
   max_output_size: z
     .number()
     .int()
     .min(1024)
     .max(100 * 1024 * 1024)
-    .default(1048576),
-  capture_stderr: z.boolean().default(true),
-  session_id: z.string().optional(),
-  create_terminal: z.boolean().default(false),
-  terminal_shell: ShellTypeSchema.optional(),
-  terminal_dimensions: DimensionsSchema.optional(),
+    .default(1048576)
+    .describe('Maximum output size in bytes'),
+  capture_stderr: z.boolean().default(true).describe('Capture standard error output'),
+  session_id: z.string().optional().describe('Session ID for session management'),
+  create_terminal: z.boolean().default(false).describe('Create a new interactive terminal session instead of running command directly'),
+  terminal_shell: ShellTypeSchema.optional().describe('Shell type for the new terminal (only used when create_terminal is true)'),
+  terminal_dimensions: DimensionsSchema.optional().describe('Terminal dimensions (only used when create_terminal is true)'),
 });
 
 export const ShellGetExecutionParamsSchema = z.object({
-  execution_id: z.string().min(1),
+  execution_id: z.string().min(1).describe('Execution ID'),
 });
 
 // Process Management
 export const ProcessListParamsSchema = z.object({
-  status_filter: z.enum(['running', 'completed', 'failed', 'all']).optional(),
-  command_pattern: z.string().optional(),
-  session_id: z.string().optional(),
-  limit: z.number().int().min(1).max(500).default(50),
-  offset: z.number().int().min(0).default(0),
+  status_filter: z.enum(['running', 'completed', 'failed', 'all']).optional().describe('Filter by process status'),
+  command_pattern: z.string().optional().describe('Filter by command pattern'),
+  session_id: z.string().optional().describe('Filter by session ID'),
+  limit: z.number().int().min(1).max(500).default(50).describe('Maximum number of results'),
+  offset: z.number().int().min(0).default(0).describe('Offset for pagination'),
 });
 
 export const ProcessKillParamsSchema = z.object({
-  process_id: z.number().int().min(1),
-  signal: ProcessSignalSchema.default('TERM'),
-  force: z.boolean().default(false),
+  process_id: z.number().int().min(1).describe('Process ID'),
+  signal: ProcessSignalSchema.default('TERM').describe('Signal to send'),
+  force: z.boolean().default(false).describe('Force termination flag'),
 });
 
 export const ProcessMonitorParamsSchema = z.object({
-  process_id: z.number().int().min(1),
-  monitor_interval_ms: z.number().int().min(100).max(60000).default(1000),
-  include_metrics: z.array(z.enum(['cpu', 'memory', 'io', 'network'])).optional(),
+  process_id: z.number().int().min(1).describe('Process ID'),
+  monitor_interval_ms: z.number().int().min(100).max(60000).default(1000).describe('Monitoring interval in milliseconds'),
+  include_metrics: z.array(z.enum(['cpu', 'memory', 'io', 'network'])).optional().describe('Metrics to monitor'),
 });
 
 // File Operations
 export const FileListParamsSchema = z.object({
-  file_type: FileTypeSchema.optional(),
-  execution_id: z.string().optional(),
-  name_pattern: z.string().optional(),
-  limit: z.number().int().min(1).max(1000).default(100),
+  file_type: FileTypeSchema.optional().describe('Filter by file type'),
+  execution_id: z.string().optional().describe('Filter by execution ID'),
+  name_pattern: z.string().optional().describe('Filter by filename pattern'),
+  limit: z.number().int().min(1).max(1000).default(100).describe('Maximum number of results'),
 });
 
 export const FileReadParamsSchema = z.object({
-  file_id: z.string().min(1),
-  offset: z.number().int().min(0).default(0),
+  file_id: z.string().min(1).describe('File ID'),
+  offset: z.number().int().min(0).default(0).describe('Read offset'),
   size: z
     .number()
     .int()
     .min(1)
     .max(10 * 1024 * 1024)
-    .default(8192),
-  encoding: z.string().default('utf-8'),
+    .default(8192)
+    .describe('Read size'),
+  encoding: z.string().default('utf-8').describe('Character encoding'),
 });
 
 export const FileDeleteParamsSchema = z.object({
-  file_ids: z.array(z.string().min(1)).min(1),
-  confirm: z.boolean(),
+  file_ids: z.array(z.string().min(1)).min(1).describe('List of file IDs to delete'),
+  confirm: z.boolean().describe('Deletion confirmation flag'),
 });
 
 // Terminal Management
 export const TerminalCreateParamsSchema = z.object({
-  session_name: z.string().optional(),
-  shell_type: ShellTypeSchema.default('bash'),
-  dimensions: DimensionsSchema.default({ width: 120, height: 30 }),
-  working_directory: z.string().optional(),
-  environment_variables: EnvironmentVariablesSchema.optional(),
-  auto_save_history: z.boolean().default(true),
+  session_name: z.string().optional().describe('Session name'),
+  shell_type: ShellTypeSchema.default('bash').describe('Shell type'),
+  dimensions: DimensionsSchema.default({ width: 120, height: 30 }).describe('Terminal dimensions'),
+  working_directory: z.string().optional().describe('Initial working directory'),
+  environment_variables: EnvironmentVariablesSchema.optional().describe('Environment variables'),
+  auto_save_history: z.boolean().default(true).describe('Auto-save command history'),
 });
 
 export const TerminalListParamsSchema = z.object({
-  session_name_pattern: z.string().optional(),
-  status_filter: z.enum(['active', 'idle', 'all']).optional(),
-  limit: z.number().int().min(1).max(200).default(50),
+  session_name_pattern: z.string().optional().describe('Session name pattern'),
+  status_filter: z.enum(['active', 'idle', 'all']).optional().describe('Filter by status'),
+  limit: z.number().int().min(1).max(200).default(50).describe('Maximum number of results'),
 });
 
 export const TerminalGetParamsSchema = z.object({
-  terminal_id: z.string().min(1),
+  terminal_id: z.string().min(1).describe('Terminal ID'),
 });
 
 export const TerminalInputParamsSchema = z.object({
-  terminal_id: z.string().min(1),
-  input: z.string(),
-  execute: z.boolean().default(false),
-  control_codes: z.boolean().default(false), // 制御コードとして解釈するかどうか
-  raw_bytes: z.boolean().default(false), // バイト列として送信するかどうか
-  send_to: z.string().optional(), // プログラムガード: "bash", "/bin/bash", "pid:12345", "sessionleader:", "*"
+  terminal_id: z.string().min(1).describe('Terminal ID'),
+  input: z.string().describe('Input content to send to terminal'),
+  execute: z.boolean().default(false).describe('Auto-execute flag (send Enter key)'),
+  control_codes: z.boolean().default(false).describe('Interpret input as control codes and escape sequences'),
+  raw_bytes: z.boolean().default(false).describe('Send input as raw bytes (hex string format)'),
+  send_to: z.string().optional().describe('Program guard target: process name, path, "pid:12345", "sessionleader:", or "*"'),
 });
 
 export const TerminalOutputParamsSchema = z.object({
-  terminal_id: z.string().min(1),
-  start_line: z.number().int().min(0).default(0),
-  line_count: z.number().int().min(1).max(10000).default(100),
-  include_ansi: z.boolean().default(false),
-  include_foreground_process: z.boolean().default(false),
+  terminal_id: z.string().min(1).describe('Terminal ID'),
+  start_line: z.number().int().min(0).default(0).describe('Start line number'),
+  line_count: z.number().int().min(1).max(10000).default(100).describe('Number of lines to get'),
+  include_ansi: z.boolean().default(false).describe('Include ANSI control codes'),
+  include_foreground_process: z.boolean().default(false).describe('Include foreground process information'),
 });
 
 export const TerminalResizeParamsSchema = z.object({
-  terminal_id: z.string().min(1),
-  dimensions: DimensionsSchema,
+  terminal_id: z.string().min(1).describe('Terminal ID'),
+  dimensions: DimensionsSchema.describe('New dimensions'),
 });
 
 export const TerminalCloseParamsSchema = z.object({
-  terminal_id: z.string().min(1),
-  save_history: z.boolean().default(true),
+  terminal_id: z.string().min(1).describe('Terminal ID'),
+  save_history: z.boolean().default(true).describe('Save command history'),
 });
 
 // Security & Monitoring
 export const SecuritySetRestrictionsParamsSchema = z.object({
-  allowed_commands: z.array(z.string()).optional(),
-  blocked_commands: z.array(z.string()).optional(),
-  allowed_directories: z.array(z.string()).optional(),
-  max_execution_time: z.number().int().min(1).max(86400).optional(),
-  max_memory_mb: z.number().int().min(1).max(32768).optional(),
-  enable_network: z.boolean().default(true),
+  allowed_commands: z.array(z.string()).optional().describe('List of allowed commands'),
+  blocked_commands: z.array(z.string()).optional().describe('List of blocked commands'),
+  allowed_directories: z.array(z.string()).optional().describe('List of allowed directories'),
+  max_execution_time: z.number().int().min(1).max(86400).optional().describe('Maximum execution time in seconds'),
+  max_memory_mb: z.number().int().min(1).max(32768).optional().describe('Maximum memory usage in MB'),
+  enable_network: z.boolean().default(true).describe('Enable network access'),
 });
 
 export const MonitoringGetStatsParamsSchema = z.object({
-  include_metrics: z.array(z.enum(['processes', 'terminals', 'files', 'system'])).optional(),
-  time_range_minutes: z.number().int().min(1).max(1440).default(60),
+  include_metrics: z.array(z.enum(['processes', 'terminals', 'files', 'system'])).optional().describe('Metrics to include'),
+  time_range_minutes: z.number().int().min(1).max(1440).default(60).describe('Time range in minutes'),
 });
 
 // Type exports


### PR DESCRIPTION
## 🐛 Bug Fix: terminal_input Schema Consistency

### Problem
The `terminal_input` tool had inconsistent schema definitions between:
- `src/types/schemas.ts` (Zod schema) - included v2.1.0 parameters
- `src/server.ts` (MCP tool schema) - missing v2.1.0 parameters

This meant that the new control code features (`control_codes`, `raw_bytes`) and program guard feature (`send_to`) were implemented but not exposed in the actual MCP tool definitions.

### Solution
1. **Fixed Schema Consistency**
   - Added missing `control_codes`, `raw_bytes`, `send_to` parameters to `terminal_input` tool schema
   - Converted all manual JSON schemas to auto-generated from Zod schemas using `zod-to-json-schema`

2. **Improved Schema Documentation**
   - Added comprehensive `.describe()` to all Zod schema parameters
   - Updated `docs/specification.md` with correct `terminal_input` parameters and response format

3. **Enhanced Maintainability**
   - Single source of truth for schemas (Zod schemas)
   - Automatic JSON Schema generation eliminates duplication
   - Better type safety and IDE support

### Changes
- 📦 Added `zod-to-json-schema` dependency
- 🔧 Fixed `terminal_input` tool schema missing v2.1.0 parameters
- 📝 Added descriptions to all Zod schema parameters
- 🔄 Converted 16 tools from manual JSON Schema to Zod auto-generation
- 📚 Updated specification documentation

### Testing
- ✅ All schemas compile without errors
- ✅ Build passes successfully
- ✅ Schema consistency verified across all tool definitions

This ensures that v2.1.0 control code and program guard features are now properly accessible through the MCP interface.