### PR TITLE
Add environment variable to disable MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ The server can be configured through environment variables or by calling the sec
 - 1GB memory limit
 - Network access enabled
 
+### Disabling Tools
+Set `MCP_DISABLED_TOOLS` to a comma-separated list of tool names to disable.
+Disabled tools will not appear in the tool list and cannot be called.
+
 ### Customizing Security
 
 Use the `security_set_restrictions` tool to configure:


### PR DESCRIPTION
## Summary
- allow disabling specific tools by name via the `MCP_DISABLED_TOOLS` environment variable
- document how to disable tools

## Testing
- `npm install`
- `npm test` *(fails: vitest / pty unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6852df9c09fc83278012ff4b6af4eae3