### PR TITLE
Fix file output initialization issue

### DIFF
--- a/src/core/file-manager.ts
+++ b/src/core/file-manager.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 import * as path from 'path';
 import { FileInfo, OutputType } from '../types/index.js';
 import {
@@ -7,6 +8,7 @@ import {
   getFileSize,
   safeReadFile,
   ensureDirectory,
+  ensureDirectorySync,
 } from '../utils/helpers.js';
 import { ResourceNotFoundError } from '../utils/errors.js';
 
@@ -18,14 +20,14 @@ export class FileManager {
   constructor(baseDir = '/tmp/mcp-shell-files', maxFiles = 10000) {
     this.baseDir = baseDir;
     this.maxFiles = maxFiles;
-    this.initializeBaseDirectory();
+    this.initializeBaseDirectorySync();
   }
 
-  private async initializeBaseDirectory(): Promise<void> {
-    await ensureDirectory(this.baseDir);
-    await ensureDirectory(path.join(this.baseDir, 'output'));
-    await ensureDirectory(path.join(this.baseDir, 'log'));
-    await ensureDirectory(path.join(this.baseDir, 'temp'));
+  private initializeBaseDirectorySync(): void {
+    ensureDirectorySync(this.baseDir);
+    ensureDirectorySync(path.join(this.baseDir, 'output'));
+    ensureDirectorySync(path.join(this.baseDir, 'log'));
+    ensureDirectorySync(path.join(this.baseDir, 'temp'));
   }
 
   async registerFile(

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -96,6 +97,15 @@ export async function ensureDirectory(dirPath: string): Promise<void> {
     await fs.access(dirPath);
   } catch {
     await fs.mkdir(dirPath, { recursive: true });
+  }
+}
+
+// ディレクトリの作成（同期版）
+export function ensureDirectorySync(dirPath: string): void {
+  try {
+    fsSync.accessSync(dirPath);
+  } catch {
+    fsSync.mkdirSync(dirPath, { recursive: true });
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure directories are created synchronously
- initialize `FileManager` paths synchronously so output files are always written

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f34e0458832789bd8c8704bb4a5f