### PR TITLE
fix: advertise listChanged in tools capability

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -65,7 +65,7 @@ export class MCPShellServer {
       },
       {
         capabilities: {
-          tools: {},
+          tools: { listChanged: true },
           logging: {}, // Enable log notification functionality
           sampling: {}, // Enable Function Calling and LLM integration capabilities
         },


### PR DESCRIPTION
## Problem

The server's `initialize` response declares `capabilities.tools` as an empty object (`{}`). Some MCP clients (observed with Claude.ai/Claude Desktop connectors) treat the absence of the `listChanged` field as a signal that the tools capability isn't really supported, and skip calling `tools/list` entirely after initialize. The practical symptom: the server shows as connected with zero visible tools, even though `tools/list` returns a full, valid tool list when called directly.

Repro (compare against `@modelcontextprotocol/server-filesystem`, which does not hit this issue):

```
curl -s -X POST <mcp-endpoint> \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
```

Before: `"capabilities":{"logging":{},"tools":{}}`
After: `"capabilities":{"logging":{},"tools":{"listChanged":true}}`

## Fix

One-line change in `src/server.ts`, declaring `tools: { listChanged: true }` instead of `tools: {}`, matching the pattern already used by `@modelcontextprotocol/server-filesystem`.

Confirmed locally that after this change and a rebuild, Claude's connector calls `tools/list` and populates the tool list correctly, where it previously connected successfully but showed no tools.

## Notes

- No behavior change to actual tool execution — this only corrects the capability advertisement.
- Build (`npm run build` / `tsc`) and quality checks pass locally.
